### PR TITLE
Remove most instances of float usage

### DIFF
--- a/Evade2/Asteroid.cpp
+++ b/Evade2/Asteroid.cpp
@@ -58,7 +58,7 @@ void Asteroid::loop(Process *me, Object *o) {
     respawn(me, o);
     return;
   }
-  o->theta += 16;
+  o->theta += FXP_RADIANS(16);
   o->vy = Camera::vy / 2;
   me->sleep(1);
 }

--- a/Evade2/Attract.cpp
+++ b/Evade2/Attract.cpp
@@ -138,7 +138,7 @@ void Attract::typewriter(Process *me, Object *o) {
     Graphics::drawVectorGraphic(Enemy::enemy_graphic(ad->enemy), 64.0, 24.0, 0.0, 2.0);
   }
   if (game_mode == MODE_CREDITS) {
-    Font::scale = .9 * 256;
+    Font::scale = 0xE6; /* 0.9 */
   }
   PGM_P p = ad->text;
   BYTE x = ad->x, y = ad->y;

--- a/Evade2/Boss.cpp
+++ b/Evade2/Boss.cpp
@@ -7,8 +7,7 @@
 #include "img/boss_2_img.h"
 #include "img/boss_3_img.h"
 
-static const FLOAT z_dist = 256;
-static const FLOAT frames = 32;
+static const FXP_WORLD_COORD z_dist = 256;
 uint16_t Boss::hit_points = 0;
 UBYTE Boss::boss_type;
 
@@ -70,10 +69,10 @@ static void engage_player_random_xy(Object *o) {
   // Font::printf(5, 15, "%f", o->y - Camera::y);
 
   if (o->state == 1) {
-    o->theta += 5 + Game::difficulty;
+    o->theta += FXP_RADIANS(5 + Game::difficulty);
   }
   else {
-    o->theta -= 5 + Game::difficulty;
+    o->theta -= FXP_RADIANS(5 + Game::difficulty);
   }
   // Debug
   // o->x = Camera::x;
@@ -114,7 +113,7 @@ static void randomize_flee(Object *o) {
   o->vx = random(-7, 7);
   o->z = Camera::z - 50;
   o->vz = Camera::vz + (random(1, 7) * Game::difficulty);
-  o->theta = random(-180, 180);
+  o->theta = FXP_RADIANS(180) - FXP_RADIANS(random(0, 360));
 }
 
 static void engage_player_flee(Object *o) {
@@ -151,7 +150,7 @@ static void engage_player_flee(Object *o) {
 
 // Copy of init_assault
 static void init_orbit(Object *o, BOOL left) {
-  FLOAT angle = left ? 0 : (2 * PI);
+  float angle = left ? 0 : (2 * PI);
   o->x = cos(angle) * 256;
   o->z = Camera::z + sin(angle) * 256;
   o->y = Camera::y + random(30, 90);
@@ -173,7 +172,7 @@ static void engage_player_orbit(Object *o) {
       o->flags &= ~ORBIT_LEFT;
     }
     else {
-      o->theta -= 12;
+      o->theta -= FXP_RADIANS(12);
     }
   }
   else {
@@ -184,11 +183,11 @@ static void engage_player_orbit(Object *o) {
       o->flags |= ORBIT_LEFT;
     }
     else {
-      o->theta += 12;
+      o->theta += FXP_RADIANS(12);
     }
   }
 
-  FLOAT rad = RADIANS(o->state);
+  float rad = RADIANS(o->state);
   o->x = cos(rad) * 512;
   o->z = Camera::z + sin(rad) * 512;
 

--- a/Evade2/Bullet.cpp
+++ b/Evade2/Bullet.cpp
@@ -37,7 +37,7 @@ void Bullet::run() {
         ObjectManager::free(o);
       }
       else {
-        o->theta += o->state;
+        o->theta += FXP_RADIANS(o->state);
       }
     }
     o = next;

--- a/Evade2/Camera.cpp
+++ b/Evade2/Camera.cpp
@@ -1,12 +1,12 @@
 #include "Evade2.h"
 
-FLOAT Camera::x = 0;
-FLOAT Camera::y = 0;
-FLOAT Camera::z = 0;
+FXP_WORLD_COORD Camera::x = 0;
+FXP_WORLD_COORD Camera::y = 0;
+FXP_WORLD_COORD Camera::z = 0;
 
-FLOAT Camera::vx = 0;
-FLOAT Camera::vy = 0;
-FLOAT Camera::vz = 0;
+FXP_WORLD_COORD Camera::vx = 0;
+FXP_WORLD_COORD Camera::vy = 0;
+FXP_WORLD_COORD Camera::vz = 0;
 
 void Camera::move() {
   Camera::x += Camera::vx;

--- a/Evade2/Camera.h
+++ b/Evade2/Camera.h
@@ -7,10 +7,8 @@ class Object;
 
 class Camera {
 public:
-  static FLOAT x, y;
-  static FLOAT z;
-  static FLOAT vx, vy;
-  static FLOAT vz;
+  static FXP_WORLD_COORD x, y, z;
+  static FXP_WORLD_COORD vx, vy, vz;
 
 public:
   static void move();

--- a/Evade2/EBullet.cpp
+++ b/Evade2/EBullet.cpp
@@ -32,7 +32,7 @@ void EBullet::run() {
       }
       else {
         // Put a wild spin on the missile
-        o->theta += (o->lines == ebomb_img) ? o->x : 40;
+        o->theta += (o->lines == ebomb_img) ? FXP_RADIANS(o->x) : FXP_RADIANS(40);
       }
     }
     o = next;
@@ -40,7 +40,7 @@ void EBullet::run() {
 }
 
 BOOL EBullet::fire(Object *oo, BYTE type) {
-  const FLOAT frames = 90 / Game::difficulty; // time to hit player (how many ticks)
+  const int16_t frames = 90 / Game::difficulty; // time to hit player (how many ticks)
 
   if (game_mode != MODE_GAME) {
     return FALSE;

--- a/Evade2/Enemy.cpp
+++ b/Evade2/Enemy.cpp
@@ -68,11 +68,11 @@ void fire(Object *o) {
   }
 }
 
-#define DELTA_THETA 8
-static void bank(Object *o, WORD delta = 45) {
+#define DELTA_THETA FXP_RADIANS(8)
+static void bank(Object *o, FXP_ANGLE delta = FXP_RADIANS(45)) {
   if (o->flags & BANK_LEFT) {
     o->theta -= DELTA_THETA;
-    if (o->theta < -delta) {
+    if (o->theta < delta) {
       o->flags &= ~BANK_LEFT;
     }
   }
@@ -87,7 +87,7 @@ static void bank(Object *o, WORD delta = 45) {
  * Initialize Object for assault enemy
  */
 static void init_assault(Object *o, BOOL left) {
-  FLOAT angle = left ? 0 : (2 * PI);
+  float angle = left ? 0 : (2 * PI);
   o->x = cos(angle) * 256;
   o->z = Camera::z + sin(angle) * 256;
   o->y = Camera::y; //  + 64 - random(0, 128);
@@ -104,7 +104,7 @@ static void init_scout(Object *o) {
   o->z = Camera::z + 1024;
   o->vz = CAMERA_VZ - 12;
   o->vx = o->vy = 0;
-  o->theta = random(-50, 50);
+  o->theta = FXP_RADIANS(90+50)-FXP_RADIANS(random(0, 100));
 }
 
 /**
@@ -130,7 +130,7 @@ void Enemy::init(Process *me, Object *o) {
   o->flags &= ~OFLAG_COLLISION;
   o->set_type(OTYPE_ENEMY);
   o->timer = FIRE_TIME;
-  o->theta = 0;
+  o->theta = FXP_RADIANS(180);
 
 
   // One enemy type enters per wave
@@ -209,8 +209,8 @@ void Enemy::run_away(Process *me, Object *o) {
   else {
     o->vz += o->state;
   }
-  o->vx += o->vx > 0 ? .1 : -.1;
-  o->vy += o->vy > 0 ? .1 : -.1;
+  o->vx += o->vx > 0 ? (256*.001) : -(256*.001);
+  o->vy += o->vy > 0 ? (256*.001) : -(256*.001);
   if (behind_camera(o) || (o->z - Camera::z) > 1024) {
     respawn(me, o);
     return;
@@ -234,7 +234,7 @@ void Enemy::evade(Process *me, Object *o) {
     me->sleep(1, explode);
     return;
   }
-  bank(o, 15);
+  bank(o, FXP_RADIANS(15));
   fire(o);
   me->sleep(1);
 }
@@ -250,7 +250,7 @@ void Enemy::seek(Process *me, Object *o) {
   }
   // bank(o);
   fire(o);
-  o->theta += 8;
+  o->theta += FXP_RADIANS(8);
   if (o->z - Camera::z < random(256, 512)) {
     o->state = -1;
     me->sleep(1, run_away);
@@ -274,7 +274,7 @@ void Enemy::orbit(Process *me, Object *o) {
       o->flags &= ~ORBIT_LEFT;
     }
     else {
-      o->theta -= 12;
+      o->theta -= FXP_RADIANS(12);
     }
   }
   else {
@@ -284,11 +284,11 @@ void Enemy::orbit(Process *me, Object *o) {
       o->flags |= ORBIT_LEFT;
     }
     else {
-      o->theta += 12;
+      o->theta += FXP_RADIANS(12);
     }
   }
 
-  FLOAT rad = RADIANS(o->state);
+  float rad = RADIANS(o->state);
   o->vy = (Camera::y > o->y) ? -2 : 2;
   o->y = Camera::y;
   o->x = cos(rad) * 256;

--- a/Evade2/Evade2.h
+++ b/Evade2/Evade2.h
@@ -64,11 +64,11 @@ const int NUM_PROCESSES = 7;
 const int NUM_STARS = 5;
 
 // joystick up/down/left/right changes camera by DELTACONTROL
-const float DELTACONTROL = 11;
+const FXP_WORLD_COORD DELTACONTROL = 11;
 // speed of camera flying through stars
-const float CAMERA_VZ = 6;
+const FXP_WORLD_COORD CAMERA_VZ = 6;
 // speed of player bullets
-const float BULLET_VZ = 15;
+const FXP_WORLD_COORD BULLET_VZ = 15;
 
 const BYTE MAX_BULLETS = 6;
 

--- a/Evade2/Evade2.h
+++ b/Evade2/Evade2.h
@@ -31,7 +31,7 @@
 
 // Modus Create LOGO splash screen first time
 #define ENABLE_MODUS_LOGO
-// #undef ENABLE_MODUS_LOGO
+#undef ENABLE_MODUS_LOGO
 
 // If FAST_LINE_ENABLE is set, the fast line drawing algorithm is used
 // While it is a bit faster, it seems to have some rounding errors that

--- a/Evade2/Font.h
+++ b/Evade2/Font.h
@@ -16,7 +16,7 @@ public:
   static BYTE write(BYTE x, BYTE y, char c);
   static BYTE _printf(BYTE x, BYTE y, const __FlashStringHelper *ifsh, ...);
 #ifdef ENABLE_ROTATING_TEXT
-  static BYTE print_string_rotatedx(BYTE x, BYTE y, FLOAT angle, const __FlashStringHelper *ifsh);
+  static BYTE print_string_rotatedx(BYTE x, BYTE y, FXP_ANGLE angle, const __FlashStringHelper *ifsh);
 #endif
   static BYTE print_string(BYTE x, BYTE y, char *s);
   static BYTE print_long(BYTE x, BYTE y, LONG n, BYTE base = 10);

--- a/Evade2/Game.cpp
+++ b/Evade2/Game.cpp
@@ -109,7 +109,7 @@ void Game::run() {
 }
 
 struct game_data {
-  FLOAT theta;
+  FXP_ANGLE theta;
   WORD timer;
 };
 
@@ -138,7 +138,7 @@ void Game::get_ready(Process *me, Object *o) {
 
 #ifdef ENABLE_ROTATING_TEXT
   Font::print_string_rotatedx(30, 35, d->theta, F("GET READY!"));
-  d->theta += 12;
+  d->theta += FXP_RADIANS(12);
 #else
   Font::printf(30, 35, "GET READY!");
 #endif
@@ -155,7 +155,7 @@ void Game::get_ready(Process *me, Object *o) {
 void Game::entry(Process *me, Object *o) {
   game_data *d = (game_data *)&o->x;
   d->timer = 65;
-  d->theta = 90;
+  d->theta = FXP_RADIANS(90);
   Sound::play_score(NEXT_WAVE_SONG);
   me->sleep(1, get_ready);
 }

--- a/Evade2/Game.h
+++ b/Evade2/Game.h
@@ -9,7 +9,6 @@ public:
   // game difficulty
   static UBYTE difficulty;
   static UBYTE kills;
-  static FLOAT z_end;
 
 public:
   // run each game loop

--- a/Evade2/GameOver.cpp
+++ b/Evade2/GameOver.cpp
@@ -6,7 +6,7 @@ void GameOver::loop(Process *me, Object *o) {
     me->suicide();
   }
 #ifdef ENABLE_ROTATING_TEXT
-  o->theta += 12;
+  o->theta += FXP_RADIANS(12);
   Font::print_string_rotatedx(30, 20, o->theta, F("GAME OVER"));
   Font::scale = .75 * 256;
   Font::printf(Game::wave < 9 ? 18 : 13, 45, "WAVES SURVIVED: %d", Game::wave - 1);

--- a/Evade2/Graphics.cpp
+++ b/Evade2/Graphics.cpp
@@ -345,7 +345,7 @@ BOOL Graphics::explodeVectorGraphic(const BYTE *graphic, float x, float y, float
       //       height = pgm_read_byte(++graphic),
       numRows = pgm_read_byte(graphic++);
 
-  float rad = float(theta) * 3.1415926 / 180,
+  float rad = RADIANS(theta / (UINT16_MAX/360)),
         sint = sin(rad),
         cost = cos(rad);
 

--- a/Evade2/Logo.cpp
+++ b/Evade2/Logo.cpp
@@ -27,7 +27,7 @@ void Logo::loop(Process *me, Object *o) {
   else {
     Graphics::drawBitmap(d->x, d->y, modus_logo_img, 0x30, 0x2b);
   }
-  if (--d->timer < 0) {
+  if (1) {
     ProcessManager::birth(Splash::entry);
     me->suicide();
   }

--- a/Evade2/Makefile
+++ b/Evade2/Makefile
@@ -4,7 +4,7 @@
 # -include ./config.mk
 
 # Set ARDUINO_DIR to your IDE install location
-ARDUINO_DIR = $(arduino_dir)
+ARDUINO_DIR = ../tools/arduino-ide/mac
 ARDMK_DIR = ../tools/Arduino-Makefile
 #AVR_TOOLS_DIR ?= EDIT_OR_CREATE_config.mk
 USER_LIB_PATH = $(realpath ./src)

--- a/Evade2/Object.cpp
+++ b/Evade2/Object.cpp
@@ -23,19 +23,19 @@ void Object::draw() {
     return;
   }
 
-  FLOAT zz = (z - Camera::z) * 2;
-  FLOAT ratio = 128 / (zz + 128);
+  FXP_WORLD_COORD zz = (z - Camera::z) * 2;
+  float ratio = 128 / (float(zz) + 128);
 
-  register FLOAT cx = (Camera::x - x) * ratio + SCREEN_WIDTH / 2;
-  register FLOAT cy = (Camera::y - y) * ratio + SCREEN_HEIGHT / 2;
+  register float cx = (Camera::x - x) * ratio + SCREEN_WIDTH / 2;
+  register float cy = (Camera::y - y) * ratio + SCREEN_HEIGHT / 2;
 
   if (flags & OFLAG_EXPLODE) {
-    Graphics::explodeVectorGraphic(lines, cx, cy, FLOAT(theta), 1 / ratio, state);
+    Graphics::explodeVectorGraphic(lines, cx, cy, theta, 1 / ratio, state);
   }
   else {
-    if (!Graphics::drawVectorGraphic(lines, cx, cy, FLOAT(theta), 1 / ratio) && (get_type() == OTYPE_ENEMY)) {
+    if (!Graphics::drawVectorGraphic(lines, cx, cy, theta, 1 / ratio) && (get_type() == OTYPE_ENEMY)) {
       // draw radar blip
-      FLOAT dx = Camera::x - x,
+      float dx = Camera::x - x,
             dy = Camera::y - y,
             angle = atan2(dy, dx);
 

--- a/Evade2/Object.h
+++ b/Evade2/Object.h
@@ -44,12 +44,12 @@ public:
   // if lines is NULL, then the variables in the Object structure can be used for any purpose
   const BYTE *lines;
   //
-  FLOAT x, y, z;    // coordinates
-  FLOAT vx, vy, vz; // velocity in x,y,z
+  FXP_WORLD_COORD x, y, z;    // coordinates
+  FXP_WORLD_COORD vx, vy, vz; // velocity in x,y,z
   UBYTE flags;
   BYTE timer;
   WORD state; // arbitrary data byte for AI use (can be explosion step, etc.)
-  WORD theta; // rotation around Z (in degrees, 0-60)
+  FXP_ANGLE theta; // rotation around Z (in normalized fixed point radians)
 
 public:
   inline void set_type(UBYTE type) {

--- a/Evade2/Splash.cpp
+++ b/Evade2/Splash.cpp
@@ -7,7 +7,7 @@ BOOL Splash::attract_mode = TRUE;
 
 struct splash_data {
 #ifdef ENABLE_ROTATING_TEXT
-  FLOAT theta; // angle of rotating text
+  FXP_ANGLE theta; // angle of rotating text
 #endif
   WORD timer;
 };
@@ -21,10 +21,7 @@ void Splash::wait(Process *me, Object *o) {
   Font::scale = 0x200;
 #ifdef ENABLE_ROTATING_TEXT
   Font::print_string_rotatedx(15, 25, d->theta, F("EVADE 2"));
-  d->theta += 10;
-  if (d->theta > 90 + 360 * 2) {
-    d->theta = 90 + 360 * 2;
-  }
+  d->theta += FXP_RADIANS(10);
 #else
   Font::printf(15, 25, "EVADE 2");
 #endif
@@ -55,7 +52,7 @@ void Splash::entry(Process *me, Object *o) {
 
   game_mode = MODE_SPLASH;
 #ifdef ENABLE_ROTATING_TEXT
-  d->theta = 90;
+  d->theta = FXP_RADIANS(90);
 #endif
   d->timer = 240;
 

--- a/Evade2/Starfield.cpp
+++ b/Evade2/Starfield.cpp
@@ -1,8 +1,7 @@
 #include "Evade2.h"
 
-WORD Starfield::starX[NUM_STARS],
-    Starfield::starY[NUM_STARS];
-FLOAT Starfield::starZ[NUM_STARS];
+FXP_WORLD_COORD Starfield::starX[NUM_STARS], Starfield::starY[NUM_STARS];
+FXP_WORLD_COORD Starfield::starZ[NUM_STARS];
 
 void Starfield::init() {
   for (int i = 0; i < NUM_STARS; i++) {
@@ -15,23 +14,22 @@ void Starfield::init() {
  */
 void Starfield::initStar(int i) {
   starX[i] = 256 - random(0, 512) + Camera::x;
-  starY[i] = 256 - random(0, 512) + Camera::y;
-  starZ[i] = Camera::z + random(200, 512);
+  starY[i] = 128 - random(0, 256) + Camera::y;
+  starZ[i] = Camera::z + random(0, 255);
 }
 
 void Starfield::render() {
-  FLOAT cz = Camera::z;
+  const FXP_WORLD_COORD cz = Camera::z;
 
   for (int i = 0; i < NUM_STARS; i++) {
-    FLOAT zz = (starZ[i] - cz) * 2;
-    if (zz < 0) {
+    FXP_WORLD_COORD zz = (starZ[i] - cz);
+    if (zz <= 0) {
       initStar(i);
-      zz = (starZ[i] - cz) * 2;
+      continue;
     }
-    FLOAT ratioX = SCREEN_WIDTH / (zz + SCREEN_WIDTH);
-    FLOAT ratioY = SCREEN_HEIGHT / (zz + SCREEN_HEIGHT);
-    WORD x = (SCREEN_WIDTH / 2) - (starX[i] - Camera::x) * ratioX;
-    WORD y = (SCREEN_HEIGHT / 2) - (starY[i] - Camera::y) * ratioY;
+    int16_t ratio = (~zz) & 0xff;
+    DISPLAY_S_COORD x = (SCREEN_WIDTH / 2) - DISPLAY_S_COORD(((starX[i] - Camera::x) * ratio)>>8);
+    DISPLAY_S_COORD y = (SCREEN_HEIGHT / 2) - DISPLAY_S_COORD(((starY[i] - Camera::y) * ratio)>>8);
     if (x & ~0x7f || y & ~0x3f) {
       initStar(i);
     }

--- a/Evade2/Starfield.h
+++ b/Evade2/Starfield.h
@@ -4,8 +4,8 @@
 #include "Evade2.h"
 
 class Starfield {
-  static WORD starX[NUM_STARS], starY[NUM_STARS];
-  static FLOAT starZ[NUM_STARS];
+  static FXP_WORLD_COORD starX[NUM_STARS], starY[NUM_STARS];
+  static FXP_WORLD_COORD starZ[NUM_STARS];
 
 protected:
   static void initStar(int i);

--- a/Evade2/Types.h
+++ b/Evade2/Types.h
@@ -11,7 +11,11 @@ typedef uint8_t BOOL;
 typedef void *APTR;
 typedef uint32_t ULONG;
 typedef int32_t LONG;
-typedef float FLOAT;
+typedef uint16_t FXP_ANGLE;
+typedef uint16_t FXP_USCALE;
+typedef int16_t FXP_SSCALE;
+typedef int16_t FXP_WORLD_COORD;
+typedef int8_t DISPLAY_S_COORD;
 
 #ifndef TRUE
 #define TRUE (!0)
@@ -28,7 +32,9 @@ typedef float FLOAT;
 #endif
 
 #ifndef RADIANS
-#define RADIANS(degrees) (FLOAT(degrees) * PI / 180)
+#define RADIANS(degrees) ((degrees) * PI / 180)
 #endif
+
+#define FXP_RADIANS(degrees) ((UINT16_MAX/360)*(degrees))
 
 #endif


### PR DESCRIPTION
This PR is not intended for merging as-is. It could be but at a minimum the game needs to be tested and constants / computation may need to be re-tuned. With a bit more effort the last instances of float could be removed (and fixed point trigonometric function used).

Aside from freed up RAM and flash, the speed gain is likely large.

Before:
```
Program:   28562 bytes (87.2% Full)
(.text + .data + .bootloader)

Data:       1929 bytes (75.4% Full)
(.data + .bss + .noinit)
```

After (with logo enabled):
```
Program:   25092 bytes (76.6% Full)
(.text + .data + .bootloader)

Data:       1715 bytes (67.0% Full)
(.data + .bss + .noinit)
```